### PR TITLE
parallelised vcf splitting

### DIFF
--- a/scripts/spear_multi.smk
+++ b/scripts/spear_multi.smk
@@ -14,10 +14,10 @@ rule split_vcfs:
    input:
       config["output_dir"] + "/all_samples.spear.vcf"
    output:
-      expand(config["output_dir"] + "/final_vcfs/{id}.spear.vcf", id = config["samples"])
+      config["output_dir"] + "/final_vcfs/{id}.spear.vcf"
    shell:
       """
-      for sample in `bcftools query -l {input}`; do bcftools view -Ov -c 1 -s $sample -o {config[output_dir]}/final_vcfs/$sample.spear.vcf {input}; done
+      bcftools view -Ov -c 1 -s {wildcards.id} -o {config[output_dir]}/final_vcfs/{wildcards.id}.spear.vcf {input}
       """
 
 rule spear:


### PR DESCRIPTION
This branch removes the single snakemake job for loop for splitting multisample VCF which was an artefact of old SPEAR format and replaces it with a parallelised splitting method that utilises as many threads as SPEAR is given. Speedup scales with threads but can result in anywhere from 10 to 25 percent speedup in runtime. 