### PR TITLE
Reworked summary anno

### DIFF
--- a/scripts/convert_format.py
+++ b/scripts/convert_format.py
@@ -7,8 +7,10 @@ import pandas as pd
 import argparse
 from pathlib import Path
 import numpy as np
-from summarise_snpeff import parse_vcf
+from summarise_snpeff import parse_vcf, write_vcf
 import csv
+import re
+from bindingcalculator import BindingCalculator
 
 def main():
 
@@ -19,9 +21,20 @@ def main():
         string_items = ",".join(c for c in list_items)
         return(string_items)
 
+    def get_contextual_bindingcalc_values(residues_list, respos, binding_calculator, option):
+        res_ret_esc_df = binding_calculator.escape_per_site(residues_list)
+        if option == "res_ret_esc":
+            res_ret_esc = res_ret_esc_df.loc[res_ret_esc_df["site"] == respos, "retained_escape"].values[0]
+            return(res_ret_esc)
+        else:
+            ab_escape_fraction = 1 - bindingcalc.binding_retained(residues_list)
+            return(ab_escape_fraction)
+
     parser = argparse.ArgumentParser(description='')
     parser.add_argument('output_dir', metavar='spear_vcfs/', type=str,
         help='Destination dir for summary tsv files')
+    parser.add_argument('data_dir', metavar='data/', type=str,
+        help='Data dir for binding calculator data files')
     parser.add_argument('--vcfs', nargs='+', required=True,
         help='Input VCF files')
     args = parser.parse_args()
@@ -29,46 +42,76 @@ def main():
     Path(f'{args.output_dir}/per_sample_annotation').mkdir(parents=True, exist_ok=True)
     
     sample_summaries = []
-    sample_summary_cols = ["sample_id", "POS", "REF", "ALT", "gene_name", "HGVS.nt", "consequence_type", "HGVS", "description", "RefSeq_acc", "residues","region", "domain", "contact_type", "NAb", "barns_class", "bloom_ace2", "VDS", "serum_escape", "mAb_escape", "cm_mAb_escape","mAb_escape_class_1","mAb_escape_class_2","mAb_escape_class_3","mAb_escape_class_4","BEC_RES", "BEC_EF"]
+    sample_summary_cols = ["sample_id", "POS", "REF", "ALT", "gene_name", "HGVS.nt", "consequence_type", "HGVS", "description", "RefSeq_acc", "residues","region", "domain", "contact_type", "NAb", "barns_class", "bloom_ace2", "VDS", "serum_escape", "mAb_escape", "cm_mAb_escape","mAb_escape_class_1","mAb_escape_class_2","mAb_escape_class_3","mAb_escape_class_4","BEC_RES", "BEC_EF", "BEC_EF_sample"]
     with open(f'{args.output_dir}/spear_annotation_summary.tsv', 'w') as f_output:
         tsv_output = csv.writer(f_output, delimiter='\t')
         tsv_output.writerow(sample_summary_cols)
     
-    scores_columns = ["sample_id","total_variants","consequence_type_variants", "region_variants", "domain_variants", "ACE2_contact_counts","ACE2_contact_score","trimer_contact_counts", "trimer_contact_score", "barns_class_variants", "bloom_ACE2" , "VDS", "serum_escape", "mAb_escape_all_classes", "mAb_escape_class_1", "mAb_escape_class_2", "mAb_escape_class_3", "mAb_escape_class_4", "BEC_RES"]
+    scores_columns = ["sample_id","total_variants","total_residue_variants", "consequence_type_variants", "region_variants", "domain_variants", "ACE2_contact_counts","ACE2_contact_score","trimer_contact_counts", "trimer_contact_score", "barns_class_variants", "bloom_ACE2" , "VDS", "serum_escape", "mAb_escape_all_classes", "mAb_escape_class_1", "mAb_escape_class_2", "mAb_escape_class_3", "mAb_escape_class_4", "BEC_RES", "BEC_EF", "BEC_EF_sample"]
     with open(f'{args.output_dir}/spear_score_summary.tsv', 'w') as f_output:
         tsv_output = csv.writer(f_output, delimiter='\t')
         tsv_output.writerow(scores_columns)
     
-    for vcf in args.vcfs:
-        sample_name = Path(Path(vcf).stem)
+    for vcf_file in args.vcfs:
+        sample_name = Path(Path(vcf_file).stem)
         sample_name = sample_name.stem #take off spear from input vcf - not very adaptable for other inputs but works for now 
-        header, vcf , infocols = parse_vcf(vcf, split_info_cols = True)
-        if len(vcf) != 0: #do not add summary if the vcf file is empty (but the empty file has to be created so need to handle). 
+        header, vcf , infocols = parse_vcf(vcf_file, split_info_cols = True)
+        original_cols = vcf.columns.tolist()
+        if len(vcf) != 0: #do not add summary if the vcf file is empty (but the empty file has to be created so need to handle).
+            #need to have two things happen here, for intergenics need to produce an output with the SUM field, for non intergenics summary output is going to come from SPEAR (or from both?) 
             vcf = vcf.loc[vcf["ANN"] != "no_annotation"]
+            total_variants = len(vcf)
+            vcf[["Gene_Name", "HGVS.c", "Annotation", "variant", "product", "protein_id", "residues"]] = vcf["SUM"].str.split("|", expand = True)
             vcf["SPEAR"] = vcf["SPEAR"].str.split(",", expand = False)
             vcf = vcf.explode("SPEAR")
-            vcf[["gene_name", "HGVS.c", "Annotation", "variant", "product", "protein_id", "residues","region", "domain", "contact_type", "NAb", "barns_class", "bloom_ace2", "VDS", "serum_escape", "mAb_escape", "cm_mAb_escape","mAb_escape_class_1","mAb_escape_class_2","mAb_escape_class_3","mAb_escape_class_4", "BEC_RES", "BEC_EF"]] = vcf["SPEAR"].str.split("|", expand = True)
-            vcf.loc[vcf["gene_name"].str.contains('-'), "gene_name"] = "Intergenic_" + vcf.loc[vcf["gene_name"].str.contains('-'), "gene_name"]
+            vcf[["residues","region", "domain", "contact_type", "NAb", "barns_class", "bloom_ace2", "VDS", "serum_escape", "mAb_escape", "cm_mAb_escape","mAb_escape_class_1","mAb_escape_class_2","mAb_escape_class_3","mAb_escape_class_4", "BEC_RES", "BEC_EF"]] = vcf["SPEAR"].str.split("|", expand = True)
+            pattern = re.compile(r"[a-zA-Z]+([0-9]+)") #matches any point mutations or deletions , not insertions. 
+            vcf["respos"] = vcf["residues"].str.extract(pattern).fillna(-1).astype("int")
+            
+            #replace the per sample bloom calculator scores with contextual per sample scores. 
+            bindingcalc = BindingCalculator(csv_or_url = f'{args.data_dir}/escape_calculator_data.csv')
+            respos_list = vcf.loc[(vcf["Gene_Name"] == "S") & (vcf["respos"] >= 331) & (vcf["respos"] <= 531), "respos"].values.tolist()
+            vcf.loc[(vcf["Gene_Name"] == "S") & (vcf["respos"] >= 331) & (vcf["respos"] <= 531), ["BEC_RES"]] = vcf.loc[(vcf["Gene_Name"] == "S") & (vcf["respos"] >= 331) & (vcf["respos"] <= 531)].apply(lambda x: get_contextual_bindingcalc_values(respos_list, x["respos"], bindingcalc, "res_ret_esc"), axis=1)
+            vcf.loc[(vcf["Gene_Name"] == "S") & (vcf["respos"] >= 331) & (vcf["respos"] <= 531), ["BEC_EF_sample"]] = vcf.loc[(vcf["Gene_Name"] == "S") & (vcf["respos"] >= 331) & (vcf["respos"] <= 531)].apply(lambda x: get_contextual_bindingcalc_values(respos_list, x["respos"], bindingcalc, "escape_fraction"), axis=1)
+
+            vcf.loc[vcf["Gene_Name"].str.contains('-'), "Gene_Name"] = "Intergenic_" + vcf.loc[vcf["Gene_Name"].str.contains('-'), "Gene_Name"]
             vcf.loc[vcf["Annotation"] == "synonymous_variant", "variant"] = vcf.loc[vcf["Annotation"] == "synonymous_variant", "HGVS.c"]
+            
+            #writing the updated bloom score vcf
+            final_vcf = vcf.copy()
+            cols = ['residues', 'region', 'domain', 'contact_type', 'NAb', 'barns_class', 'bloom_ace2', 'VDS', 'serum_escape', 'mAb_escape', 'cm_mAb_escape', 'mAb_escape_class_1', 'mAb_escape_class_2', 'mAb_escape_class_3', 'mAb_escape_class_4', 'BEC_RES', 'BEC_EF', 'BEC_EF_sample']
+            final_vcf["SPEAR"] = final_vcf[cols].apply(lambda row: '|'.join(row.values.astype(str)), axis=1)
+            all_cols = final_vcf.columns.tolist()
+            final_vcf.drop([col for col in all_cols if col not in original_cols], axis = 1, inplace = True)
+            cols = [e for e in final_vcf.columns.to_list() if e not in ("SPEAR")]
+            final_vcf = final_vcf.groupby(cols, as_index = False).agg({"SPEAR": list})
+            final_vcf["SPEAR"] = [','.join(map(str, l)) for l in final_vcf["SPEAR"].apply(lambda x: sorted(x, key = lambda y: re.search(r'^[a-zA-Z]+([0-9]+)|',y)[1]))] #sorting like this because the groupby list doesnt always put residues in correct order.
+            for col in infocols:
+                final_vcf[col] = col + "=" + final_vcf[col]
+            final_vcf['INFO'] = final_vcf[infocols].agg(';'.join, axis=1)
+            final_vcf.drop(infocols, axis = 1, inplace = True)
+            original_cols = [col for col in original_cols if col not in infocols]
+            original_cols.insert(original_cols.index("FILTER") + 1, "INFO")
+            final_vcf = final_vcf[original_cols]
+            write_vcf(header,final_vcf,vcf_file)
+
             per_sample_output = vcf.copy()
             per_sample_output["sample_id"] = sample_name
-            cols = ["sample_id", "POS", "REF", "ALT", "gene_name", "HGVS.c", "Annotation", "variant", "product", "protein_id", "residues","region", "domain", "contact_type", "NAb", "barns_class", "bloom_ace2", "VDS", "serum_escape", "mAb_escape", "cm_mAb_escape","mAb_escape_class_1","mAb_escape_class_2","mAb_escape_class_3","mAb_escape_class_4", "BEC_RES","BEC_EF"]
-            per_sample_output[["region", "domain", "contact_type", "NAb", "barns_class", "bloom_ace2", "VDS", "serum_escape", "mAb_escape", "cm_mAb_escape","mAb_escape_class_1","mAb_escape_class_2","mAb_escape_class_3","mAb_escape_class_4", "BEC_RES", "BEC_EF"]] = per_sample_output[["region", "domain", "contact_type", "NAb", "barns_class", "bloom_ace2", "VDS", "serum_escape", "mAb_escape", "cm_mAb_escape","mAb_escape_class_1","mAb_escape_class_2","mAb_escape_class_3","mAb_escape_class_4", "BEC_RES","BEC_EF"]].replace("[^-0-9a-zA-Z]+[~]+", "", regex = True)
-            per_sample_output[["residues","region", "domain", "contact_type", "NAb", "barns_class", "bloom_ace2", "VDS", "serum_escape", "mAb_escape", "cm_mAb_escape","mAb_escape_class_1","mAb_escape_class_2","mAb_escape_class_3","mAb_escape_class_4","BEC_RES", "BEC_EF"]] = per_sample_output[["residues","region", "domain", "contact_type", "NAb", "barns_class", "bloom_ace2", "VDS", "serum_escape", "mAb_escape", "cm_mAb_escape","mAb_escape_class_1","mAb_escape_class_2","mAb_escape_class_3","mAb_escape_class_4","BEC_RES", "BEC_EF"]].replace("~",",", regex = True)
+            cols = ["sample_id", "POS", "REF", "ALT", "Gene_Name", "HGVS.c", "Annotation", "variant", "product", "protein_id", "residues","region", "domain", "contact_type", "NAb", "barns_class", "bloom_ace2", "VDS", "serum_escape", "mAb_escape", "cm_mAb_escape","mAb_escape_class_1","mAb_escape_class_2","mAb_escape_class_3","mAb_escape_class_4", "BEC_RES","BEC_EF", "BEC_EF_sample"]
             per_sample_output = per_sample_output[cols]
-            per_sample_output.columns = ["sample_id", "POS", "REF", "ALT", "gene_name", "HGVS.nt", "consequence_type", "HGVS", "description", "RefSeq_acc", "residues","region", "domain", "contact_type", "NAb", "barns_class", "bloom_ace2", "VDS", "serum_escape", "mAb_escape", "cm_mAb_escape","mAb_escape_class_1","mAb_escape_class_2","mAb_escape_class_3","mAb_escape_class_4", "BEC_RES", "BEC_EF"] 
+            per_sample_output.columns = ["sample_id", "POS", "REF", "ALT", "Gene_Name", "HGVS.nt", "consequence_type", "HGVS", "description", "RefSeq_acc", "residues","region", "domain", "contact_type", "NAb", "barns_class", "bloom_ace2", "VDS", "serum_escape", "mAb_escape", "cm_mAb_escape","mAb_escape_class_1","mAb_escape_class_2","mAb_escape_class_3","mAb_escape_class_4", "BEC_RES", "BEC_EF", "BEC_EF_sample"] 
             per_sample_output.to_csv(f'{args.output_dir}/per_sample_annotation/{sample_name}.spear.annotation.summary.tsv', sep = '\t', header = True, index = False)
             per_sample_output.to_csv(f'{args.output_dir}/spear_annotation_summary.tsv', sep = '\t', mode='a', header=False, index = False)
 
             #now getting summary scores
-            sample_variant_number = len(per_sample_output)
+            sample_residue_variant_number = len(per_sample_output)
             consequence_type_counts = per_sample_output.groupby(["consequence_type"]).size()
             type_string = df_counts_to_string(consequence_type_counts)
             region_counts = per_sample_output["region"].str.split(",").explode().replace(r'^\s*$', np.nan, regex=True).value_counts()
             region_string = df_counts_to_string(region_counts)
             domain_counts = per_sample_output["domain"].str.split(",").explode().replace(r'^\s*$', np.nan, regex=True).value_counts()
             domain_string = df_counts_to_string(domain_counts)
-            if per_sample_output["contact_type"].isin([""]).all():
+            if per_sample_output["contact_type"].isin([""]).all(): #if there are no contact types in SPEAR annotation
                 ace2_contacts_score = ""
                 trimer_contacts_score = ""
                 ace2_contacts_sum = ""
@@ -86,6 +129,7 @@ def main():
                 contacts_counts = contacts_df.groupby(["contact"]).count()
                 ace2_contacts_sum = contacts_counts.loc[contacts_scores.index=="ACE2", "contact_type"].values[0] if len(contacts_counts.loc[contacts_scores.index=="ACE2", "contact_type"].values) == 1 else ""
                 trimer_contacts_sum = contacts_counts.loc[contacts_scores.index=="trimer", "contact_type"].values[0] if len(contacts_counts.loc[contacts_scores.index=="trimer", "contact_type"].values) == 1 else ""
+            
             if per_sample_output["barns_class"].isin([""]).all():
                 barns_string = ""
             else:
@@ -93,67 +137,72 @@ def main():
                 barns_counts.index = "class_" + barns_counts.index
                 barns_string = df_counts_to_string(barns_counts)
             
+            #rethink this part at some point
+
             if per_sample_output["bloom_ace2"].isin([""]).all():
                 bloom_ace2_sum = ""
             else:
-                bloom_ace2_sum = per_sample_output["bloom_ace2"].str.split(",").explode().replace(r'^\s*$', np.nan, regex=True).astype("float").sum()
+                bloom_ace2_sum = per_sample_output["bloom_ace2"].replace(r'^\s*$', np.nan, regex=True).astype("float").mean()
             
             if per_sample_output["VDS"].isin([""]).all():
                 vds_sum = ""
             else:
-                vds_sum = per_sample_output["VDS"].str.split(",").explode().replace(r'^\s*$', np.nan, regex=True).astype("float").sum()
+                vds_sum = per_sample_output["VDS"].replace(r'^\s*$', np.nan, regex=True).astype("float").mean()
 
             if per_sample_output["serum_escape"].isin([""]).all():
                 serum_escape_sum = ""
             else:
-                serum_escape_sum = per_sample_output["serum_escape"].str.split(",").explode().replace(r'^\s*$', np.nan, regex=True).astype("float").sum()
+                serum_escape_sum = per_sample_output["serum_escape"].replace(r'^\s*$', np.nan, regex=True).astype("float").mean()
             
             if per_sample_output["mAb_escape"].isin([""]).all():
                 mab_escape_all_sum = ""
             else:
-                mab_escape_all_sum = per_sample_output["mAb_escape"].str.split(",").explode().replace(r'^\s*$', np.nan, regex=True).astype("float").sum()
+                mab_escape_all_sum = per_sample_output["mAb_escape"].replace(r'^\s*$', np.nan, regex=True).astype("float").mean()
             
             if per_sample_output["mAb_escape_class_1"].isin([""]).all():
                 mab_escape_class_1_sum = ""
             else:
-                mab_escape_class_1_sum = per_sample_output["mAb_escape_class_1"].str.split(",").explode().replace(r'^\s*$', np.nan, regex=True).astype("float").sum()
+                mab_escape_class_1_sum = per_sample_output["mAb_escape_class_1"].replace(r'^\s*$', np.nan, regex=True).astype("float").mean()
             
             if per_sample_output["mAb_escape_class_2"].isin([""]).all():
                 mab_escape_class_2_sum = ""
             else:
-                mab_escape_class_2_sum = per_sample_output["mAb_escape_class_2"].str.split(",").explode().replace(r'^\s*$', np.nan, regex=True).astype("float").sum()
+                mab_escape_class_2_sum = per_sample_output["mAb_escape_class_2"].replace(r'^\s*$', np.nan, regex=True).astype("float").mean()
             
             if per_sample_output["mAb_escape_class_3"].isin([""]).all():
                 mab_escape_class_3_sum = ""
             else:    
-                mab_escape_class_3_sum = per_sample_output["mAb_escape_class_3"].str.split(",").explode().replace(r'^\s*$', np.nan, regex=True).astype("float").sum()
+                mab_escape_class_3_sum = per_sample_output["mAb_escape_class_3"].replace(r'^\s*$', np.nan, regex=True).astype("float").mean()
             
             if per_sample_output["mAb_escape_class_4"].isin([""]).all():
                 mab_escape_class_4_sum = ""
             else:
-                mab_escape_class_4_sum = per_sample_output["mAb_escape_class_4"].str.split(",").explode().replace(r'^\s*$', np.nan, regex=True).astype("float").sum()
+                mab_escape_class_4_sum = per_sample_output["mAb_escape_class_4"].replace(r'^\s*$', np.nan, regex=True).astype("float").mean()
             
-            # if per_sample_output["BEC_sample_EF"].isin([""]).all():
-            #     bec_sample_ef_score = ""
-            # else:
-            #     bec_sample_ef_score = per_sample_output["BEC_sample_EF"].str.split(",").explode().replace(r'^\s*$', np.nan, regex=True).astype("float").mean()
-            
+            if per_sample_output["BEC_EF"].isin([""]).all():
+                bec_ef_score = ""
+            else:
+                bec_ef_score = per_sample_output["BEC_EF"].replace(r'^\s*$', np.nan, regex=True).astype("float").mean()
+            if per_sample_output["BEC_EF_sample"].isin([""]).all():
+                bec_ef_sample_score = ""
+            else:
+                bec_ef_sample_score = per_sample_output["BEC_EF_sample"].replace(r'^\s*$', np.nan, regex=True).astype("float").mean()
             if per_sample_output["BEC_RES"].isin([""]).all():
                 bec_res_score = ""
             else:
-                bec_res_score = per_sample_output["BEC_RES"].str.split(",").explode().replace(r'^\s*$', np.nan, regex=True).astype("float").sum()
-                
-            scores_list = [sample_name,sample_variant_number, type_string, region_string, domain_string,ace2_contacts_sum, ace2_contacts_score, trimer_contacts_sum,trimer_contacts_score, barns_string,bloom_ace2_sum , vds_sum, serum_escape_sum, mab_escape_all_sum, mab_escape_class_1_sum, mab_escape_class_2_sum, mab_escape_class_3_sum, mab_escape_class_4_sum, bec_res_score] #bec_sample_ef_score
+                bec_res_score = per_sample_output["BEC_RES"].replace(r'^\s*$', np.nan, regex=True).astype("float").mean()
+
+            scores_list = [sample_name,total_variants,sample_residue_variant_number, type_string, region_string, domain_string,ace2_contacts_sum, ace2_contacts_score, trimer_contacts_sum,trimer_contacts_score, barns_string,bloom_ace2_sum , vds_sum, serum_escape_sum, mab_escape_all_sum, mab_escape_class_1_sum, mab_escape_class_2_sum, mab_escape_class_3_sum, mab_escape_class_4_sum, bec_res_score, bec_ef_score, bec_ef_sample_score]
             scores_df = pd.DataFrame([scores_list], columns=scores_columns)
             scores_df.to_csv(f'{args.output_dir}/spear_score_summary.tsv', sep = '\t', mode='a', header=False, index = False)
 
             #now gofasta style output 
             vcf["variant"] = vcf["Annotation"] + "_" + vcf["variant"]
-            new_df = vcf[["gene_name", "variant"]].copy()
-            new_df = new_df.groupby("gene_name")["variant"].apply(list).to_frame()
+            new_df = vcf[["Gene_Name", "variant"]].copy()
+            new_df = new_df.groupby("Gene_Name")["variant"].apply(list).to_frame()
             new_df["variant"] = new_df["variant"].str.join("|")
-            new_df = new_df.reset_index().rename(columns={new_df.index.name:'gene_name'})
-            new_df["cat"] =  new_df["gene_name"] + ":" + new_df["variant"]
+            new_df = new_df.reset_index().rename(columns={new_df.index.name:'Gene_Name'})
+            new_df["cat"] =  new_df["Gene_Name"] + ":" + new_df["variant"]
             sample_variants = new_df["cat"].to_list()
             sample_variants = ";".join(sample_variants)
             sample_summary = [sample_name, sample_variants]

--- a/scripts/convert_format.py
+++ b/scripts/convert_format.py
@@ -73,6 +73,7 @@ def main():
             respos_list = vcf.loc[(vcf["Gene_Name"] == "S") & (vcf["respos"] >= 331) & (vcf["respos"] <= 531), "respos"].values.tolist()
             vcf.loc[(vcf["Gene_Name"] == "S") & (vcf["respos"] >= 331) & (vcf["respos"] <= 531), ["BEC_RES"]] = vcf.loc[(vcf["Gene_Name"] == "S") & (vcf["respos"] >= 331) & (vcf["respos"] <= 531)].apply(lambda x: get_contextual_bindingcalc_values(respos_list, x["respos"], bindingcalc, "res_ret_esc"), axis=1)
             vcf.loc[(vcf["Gene_Name"] == "S") & (vcf["respos"] >= 331) & (vcf["respos"] <= 531), ["BEC_EF_sample"]] = vcf.loc[(vcf["Gene_Name"] == "S") & (vcf["respos"] >= 331) & (vcf["respos"] <= 531)].apply(lambda x: get_contextual_bindingcalc_values(respos_list, x["respos"], bindingcalc, "escape_fraction"), axis=1)
+            vcf["BEC_EF_sample"] = vcf["BEC_EF_sample"].fillna("")
 
             vcf.loc[vcf["Gene_Name"].str.contains('-'), "Gene_Name"] = "Intergenic_" + vcf.loc[vcf["Gene_Name"].str.contains('-'), "Gene_Name"]
             vcf.loc[vcf["Annotation"] == "synonymous_variant", "variant"] = vcf.loc[vcf["Annotation"] == "synonymous_variant", "HGVS.c"]

--- a/scripts/convert_format.py
+++ b/scripts/convert_format.py
@@ -62,6 +62,7 @@ def main():
             vcf = vcf.loc[vcf["ANN"] != "no_annotation"]
             total_variants = len(vcf)
             vcf[["Gene_Name", "HGVS.c", "Annotation", "variant", "product", "protein_id", "residues"]] = vcf["SUM"].str.split("|", expand = True)
+            consequence_type_counts = vcf.groupby(["Annotation"]).size() #get the nucleotide variant conseqeunce type counts before exploding the vcf into per residue format
             vcf["SPEAR"] = vcf["SPEAR"].str.split(",", expand = False)
             vcf = vcf.explode("SPEAR")
             vcf[["residues","region", "domain", "contact_type", "NAb", "barns_class", "bloom_ace2", "VDS", "serum_escape", "mAb_escape", "cm_mAb_escape","mAb_escape_class_1","mAb_escape_class_2","mAb_escape_class_3","mAb_escape_class_4", "BEC_RES", "BEC_EF"]] = vcf["SPEAR"].str.split("|", expand = True)
@@ -106,7 +107,6 @@ def main():
 
             #now getting summary scores
             sample_residue_variant_number = len(per_sample_output)
-            consequence_type_counts = per_sample_output.groupby(["consequence_type"]).size()
             type_string = df_counts_to_string(consequence_type_counts)
             region_counts = per_sample_output["region"].str.split(",").explode().replace(r'^\s*$', np.nan, regex=True).value_counts()
             region_string = df_counts_to_string(region_counts)

--- a/scripts/spear_annotate.py
+++ b/scripts/spear_annotate.py
@@ -144,7 +144,7 @@ def main():
         df = vcf.iloc[:,:vcf.columns.get_loc("FORMAT")] 
         df = df.replace(np.nan, '', regex=True)
         samples = vcf.iloc[:,vcf.columns.get_loc("FORMAT"):] #split format and sample columns into separate dataframe to prevent fragmentation whilst annotating
-        header.append(f'##INFO=<ID=SPEAR,Number=.,Type=String,Description="SPEAR Tool Annotations: \'residue | region | domain | contact_type | NAb | barns_class | bloom_ace2 | VDS | serum_escape | mAb_escape | cm_mAb_escape | mAb_escape_class_1 | mAb_escape_class_2 | mAb_escape_class_3 | mAb_escape_class_4 | BEC_RES | BEC_EF  \'">') #MAKE VARIANT HEADER HGVS
+        header.append(f'##INFO=<ID=SPEAR,Number=.,Type=String,Description="SPEAR Tool Annotations: \'residue | region | domain | contact_type | NAb | barns_class | bloom_ace2 | VDS | serum_escape | mAb_escape | cm_mAb_escape | mAb_escape_class_1 | mAb_escape_class_2 | mAb_escape_class_3 | mAb_escape_class_4 | BEC_RES | BEC_EF | BEC_EF_sample  \'">') #MAKE VARIANT HEADER HGVS
         df = annotate_s_residues(df.copy(), args.data_dir)
 
         cols = [e for e in df.columns.to_list() if e not in ("ANN", "SUM", "SPEAR")]
@@ -174,4 +174,4 @@ def main():
   
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/scripts/spear_annotate.py
+++ b/scripts/spear_annotate.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+
+from typing_extensions import final
+
+from pandas.io.pytables import dropna_doc
+from Bio import SeqIO
+import warnings
+warnings.simplefilter(action='ignore', category=FutureWarning)
+import pandas as pd
+from itertools import takewhile
+import argparse
+import numpy as np
+import re
+from shutil import copy
+from bindingcalculator import BindingCalculator
+from summarise_snpeff import parse_vcf , write_vcf
+
+def natural_key(string_):
+    """See https://blog.codinghorror.com/sorting-for-humans-natural-sort-order/"""
+    return [int(s) if s.isdigit() else s for s in re.split(r'(\d+)', string_)]
+    
+def annotate_s_residues(vcf, data_dir):
+    def extract_df_scores(scores_matrix, respos, altres):
+        return(scores_matrix.loc[respos, altres])
+
+    def get_bindingcalc_values(respos, binding_calculator, option):
+        res_ret_esc_df = binding_calculator.escape_per_site([respos])
+        if option == "res_ret_esc":
+            res_ret_esc = res_ret_esc_df.loc[res_ret_esc_df["site"] == respos, "retained_escape"].values[0]
+            return(res_ret_esc)
+        else:
+            ab_escape_fraction = 1 - bindingcalc.binding_retained([respos])
+            return(ab_escape_fraction)
+
+    spear_anno_file = pd.read_pickle(f'{data_dir}/spear.pkl')
+    spear_anno_file["mod_barns_class_mask_sum_gt0.75"] = spear_anno_file["mod_barns_class_mask_sum_gt0.75"].replace("", -1).astype(int)
+    bloom_ace2_file = pd.read_csv(f'{data_dir}/single_mut_effects.csv')
+    bloom_escape_all = pd.read_csv(f'{data_dir}/Bloom_mAb_escape_all_class.csv', index_col = 0)
+    bloom_escape_class1 = pd.read_csv(f'{data_dir}/Bloom_mAb_escape_class_1.csv', index_col = 0)
+    bloom_escape_class2 = pd.read_csv(f'{data_dir}/Bloom_mAb_escape_class_2.csv', index_col = 0)
+    bloom_escape_class3 = pd.read_csv(f'{data_dir}/Bloom_mAb_escape_class_3.csv', index_col = 0)
+    bloom_escape_class4 = pd.read_csv(f'{data_dir}/Bloom_mAb_escape_class_4.csv', index_col = 0)
+    greaney_serum_escape = pd.read_csv(f'{data_dir}/Greaney_serum_escape.csv', index_col = 0)
+    vds = pd.read_csv(f'{data_dir}/vibentropy_occupancy_dmsdata.csv')
+    
+    bindingcalc = BindingCalculator(csv_or_url = f'{data_dir}/escape_calculator_data.csv')    
+    
+    vcf[["gene_name", "HGVS.c", "Annotation", "variant", "product", "protein_id", "residues"]] = vcf["SUM"].str.split("|", expand = True)
+    vcf["residues"] = vcf["residues"].str.split('~')
+    vcf = vcf.explode("residues")
+    vcf.reset_index(inplace = True)
+    
+    pattern = re.compile(r"[a-zA-Z]+([0-9]+)") #matches any point mutations or deletions , not insertions. 
+    vcf["respos"] = vcf["residues"].str.extract(pattern).fillna(-1).astype("int")
+    vcf = pd.merge(vcf,spear_anno_file[["ORF", "AA_coordinate","region", "domain", "contact_type", "NAb", "barns_class", "mod_barns_class_mask_sum_gt0.75"]],left_on = ["gene_name", "respos"], right_on = ["ORF","AA_coordinate"],how="left")
+    vcf["mod_barns_class_mask_sum_gt0.75"] = vcf["mod_barns_class_mask_sum_gt0.75"].replace("", -1).fillna(-1).astype(int)
+    bloom_ace2_file["ORF"] = "S"
+    vcf = pd.merge(vcf,bloom_ace2_file[["ORF", "mutation", "bind_avg"]], left_on = ["gene_name", "residues"], right_on = ["ORF", "mutation"], how = "left")
+    vcf.drop(["ORF_x", "AA_coordinate"], axis = 1, inplace = True)
+    vds["ORF"] = "S"
+    vds["mutation_residues"] = vds["wildtype"] + vds["site"].astype("str") + vds["mutation"]
+    vcf = pd.merge(vcf, vds[["ORF", "mutation_residues", "mut_VDS"]], left_on = ["gene_name","residues"], right_on = ["ORF", "mutation_residues"], how = "left")
+    vcf["alt_res"] = vcf["residues"].str.extract("[A-Z]+[0-9]+([A-Z]+)")
+    
+    vcf.loc[(vcf["gene_name"] == "S") & (vcf["respos"] >= 331) & (vcf["respos"] <= 531) , "bloom_escape_all"] = vcf.loc[(vcf["gene_name"] == "S") & (vcf["respos"] >= 331) & (vcf["respos"] <= 531)].apply(lambda x: extract_df_scores(bloom_escape_all, x["respos"], x["alt_res"]), axis=1)
+    vcf.loc[(vcf["gene_name"] == "S") & (vcf["respos"] >= 331) & (vcf["respos"] <= 531) , "serum_escape"] = vcf.loc[(vcf["gene_name"] == "S") & (vcf["respos"] >= 331) & (vcf["respos"] <= 531)].apply(lambda x: extract_df_scores(greaney_serum_escape, x["respos"], x["alt_res"]), axis=1)
+    
+    #make a copy of the barns classes to explode on
+    vcf["mod_barns_class"] = vcf["mod_barns_class_mask_sum_gt0.75"].replace(-1, "").fillna("").astype("str")
+    vcf["mod_barns_class"] = vcf["mod_barns_class"].fillna("")
+    vcf["mod_barns_class"] = vcf["mod_barns_class"].astype("str")
+    vcf.loc[vcf["mod_barns_class"] != "", "mod_barns_class"] = vcf.loc[vcf["mod_barns_class"] != "", "mod_barns_class"] + "*"
+    vcf.loc[(vcf["barns_class"] != "") & (vcf["mod_barns_class"] != ""), "mod_barns_class"] = vcf.loc[(vcf["barns_class"] != "") & (vcf["mod_barns_class"] != ""),"barns_class"] + "+" + vcf.loc[(vcf["barns_class"] != "") & (vcf["mod_barns_class"] != ""),"mod_barns_class"]
+    vcf.loc[vcf["mod_barns_class"] == "", "mod_barns_class"] = vcf.loc[vcf["mod_barns_class"] == "", "barns_class"]
+    vcf.loc[(vcf["barns_class"] == "") & (vcf["mod_barns_class"] != ""), "mod_barns_class"] = vcf["mod_barns_class"]
+    vcf["mod_barns_class"] = vcf["mod_barns_class"].str.split("+", expand = False)
+    vcf.loc[vcf["mod_barns_class"].notna() , "mod_barns_class"] = vcf.loc[vcf["mod_barns_class"].notna() , "mod_barns_class"].apply(lambda x: sorted(x, key = natural_key))
+    vcf.loc[vcf["mod_barns_class"].notna(), "mod_barns_class"] = vcf.loc[vcf["mod_barns_class"].notna(), "mod_barns_class"].str.join("+")
+    
+    vcf["barns_class"] = vcf["barns_class"].str.split("+")
+    vcf = vcf.explode("barns_class")
+    vcf["barns_class"] = vcf["barns_class"].replace("", -1).fillna(-1).astype("int")
+
+    vcf.loc[(vcf["gene_name"] == "S") & (vcf["barns_class"] == 1), "mAb_class_1_escape"] = vcf.loc[(vcf["gene_name"] == "S") & (vcf["barns_class"] == 1)].apply(lambda x: extract_df_scores(bloom_escape_class1, x["respos"], x["alt_res"]), axis=1).fillna("")
+    vcf.loc[(vcf["gene_name"] == "S") & (vcf["barns_class"] == 2), "mAb_class_2_escape"] = vcf.loc[(vcf["gene_name"] == "S") & (vcf["barns_class"] == 2)].apply(lambda x: extract_df_scores(bloom_escape_class2, x["respos"], x["alt_res"]), axis=1).fillna("")
+    vcf.loc[(vcf["gene_name"] == "S") & (vcf["barns_class"] == 3), "mAb_class_3_escape"] = vcf.loc[(vcf["gene_name"] == "S") & (vcf["barns_class"] == 3)].apply(lambda x: extract_df_scores(bloom_escape_class3, x["respos"], x["alt_res"]), axis=1).fillna("")
+    vcf.loc[(vcf["gene_name"] == "S") & (vcf["barns_class"] == 4), "mAb_class_4_escape"] = vcf.loc[(vcf["gene_name"] == "S") & (vcf["barns_class"] == 4)].apply(lambda x: extract_df_scores(bloom_escape_class4, x["respos"], x["alt_res"]), axis=1).fillna("")
+
+    vcf.loc[(vcf["gene_name"] == "S") & (vcf["mod_barns_class_mask_sum_gt0.75"] == 1), "mAb_class_1_escape"] = vcf.loc[(vcf["gene_name"] == "S") & (vcf["mod_barns_class_mask_sum_gt0.75"] == 1)].apply(lambda x: extract_df_scores(bloom_escape_class1, x["respos"], x["alt_res"]), axis=1).fillna("")
+    vcf.loc[(vcf["gene_name"] == "S") & (vcf["mod_barns_class_mask_sum_gt0.75"] == 2), "mAb_class_2_escape"] = vcf.loc[(vcf["gene_name"] == "S") & (vcf["mod_barns_class_mask_sum_gt0.75"] == 2)].apply(lambda x: extract_df_scores(bloom_escape_class2, x["respos"], x["alt_res"]), axis=1).fillna("")
+    vcf.loc[(vcf["gene_name"] == "S") & (vcf["mod_barns_class_mask_sum_gt0.75"] == 3), "mAb_class_3_escape"] = vcf.loc[(vcf["gene_name"] == "S") & (vcf["mod_barns_class_mask_sum_gt0.75"] == 3)].apply(lambda x: extract_df_scores(bloom_escape_class3, x["respos"], x["alt_res"]), axis=1).fillna("")
+    vcf.loc[(vcf["gene_name"] == "S") & (vcf["mod_barns_class_mask_sum_gt0.75"] == 4), "mAb_class_4_escape"] = vcf.loc[(vcf["gene_name"] == "S") & (vcf["mod_barns_class_mask_sum_gt0.75"] == 4)].apply(lambda x: extract_df_scores(bloom_escape_class4, x["respos"], x["alt_res"]), axis=1)    
+    
+    vcf["mAb_class_1_escape"] = vcf["mAb_class_1_escape"].fillna("").astype("str")
+    vcf["mAb_class_2_escape"] = vcf["mAb_class_2_escape"].fillna("").astype("str")
+    vcf["mAb_class_3_escape"] = vcf["mAb_class_3_escape"].fillna("").astype("str")
+    vcf["mAb_class_4_escape"] = vcf["mAb_class_4_escape"].fillna("").astype("str")
+
+    vcf["mod_barns_class_mask_sum_gt0.75"] = vcf["mod_barns_class_mask_sum_gt0.75"].replace(-1, "").astype("str")
+
+    cols = [e for e in vcf.columns.to_list() if e not in ("barns_class","mAb_class_1_escape", "mAb_class_2_escape", "mAb_class_3_escape", "mAb_class_4_escape")]
+    vcf = vcf.groupby(cols, as_index = False, dropna = False).agg(set)
+
+    vcf["mAb_class_1_escape"] = [''.join(map(str, l)) for l in vcf["mAb_class_1_escape"]]
+    vcf["mAb_class_2_escape"] = [''.join(map(str, l)) for l in vcf["mAb_class_2_escape"]]
+    vcf["mAb_class_3_escape"] = [''.join(map(str, l)) for l in vcf["mAb_class_3_escape"]]
+    vcf["mAb_class_4_escape"] = [''.join(map(str, l)) for l in vcf["mAb_class_4_escape"]]
+
+    vcf["mAb_class_1_escape"] = vcf["mAb_class_1_escape"].replace("", np.nan).astype("float")
+    vcf["mAb_class_2_escape"] = vcf["mAb_class_2_escape"].replace("", np.nan).astype("float")
+    vcf["mAb_class_3_escape"] = vcf["mAb_class_3_escape"].replace("", np.nan).astype("float")
+    vcf["mAb_class_4_escape"] = vcf["mAb_class_4_escape"].replace("", np.nan).astype("float")
+    
+    
+    vcf["barns_class"] = vcf["mod_barns_class"]
+    vcf.drop(["mod_barns_class"], axis = 1 , inplace = True)
+
+    vcf["cm_mab_escape"] = vcf[["mAb_class_1_escape","mAb_class_2_escape","mAb_class_3_escape","mAb_class_4_escape"]].mean(axis=1)
+
+    vcf.loc[(vcf["gene_name"] == "S") & (vcf["respos"] >= 331) & (vcf["respos"] <= 531), ["BEC_RES"]] = vcf.loc[(vcf["gene_name"] == "S") & (vcf["respos"] >= 331) & (vcf["respos"] <= 531)].apply(lambda x: get_bindingcalc_values(x["respos"], bindingcalc, "res_ret_esc"), axis=1)
+    vcf.loc[(vcf["gene_name"] == "S") & (vcf["respos"] >= 331) & (vcf["respos"] <= 531), ["BEC_EF"]] = vcf.loc[(vcf["gene_name"] == "S") & (vcf["respos"] >= 331) & (vcf["respos"] <= 531)].apply(lambda x: get_bindingcalc_values(x["respos"], bindingcalc, "escape_fraction"), axis=1)
+
+    vcf = vcf.fillna("")
+    print(vcf.columns)
+    cols = ['residues', 'region', 'domain', 'contact_type', 'NAb', 'barns_class', 'bind_avg', 'mut_VDS', 'serum_escape', 'bloom_escape_all', 'cm_mab_escape', 'mAb_class_1_escape', 'mAb_class_2_escape', 'mAb_class_3_escape', 'mAb_class_4_escape', 'BEC_RES', 'BEC_EF']
+    vcf["SPEAR"] = vcf[cols].apply(lambda row: '|'.join(row.values.astype(str)), axis=1)
+    all_cols = vcf.columns.tolist()
+    vcf.drop([col for col in all_cols if col not in ['#CHROM', 'POS', 'ID', 'REF', 'ALT', 'QUAL', 'FILTER', 'AC','AN', 'ANN', 'SUM', "SPEAR" ]], axis = 1, inplace = True)
+    return vcf
+
+def main():
+    #this is a different approach to this where each residue has spear annotation rather than super concatenated representation. Will still be able to represent the csv in same way but vcf will look slightly different. 
+    parser = argparse.ArgumentParser(description='')
+    parser.add_argument('output_filename', metavar='spear_vcfs/merged.spear.vcf', type=str,
+        help='Filename for SPEAR annotated VCF') #ADD A DEFAULT FOR THIS 
+    parser.add_argument('vcf', metavar='path/to/vcf', type = str,
+        help='Input VCF file')
+    parser.add_argument('data_dir', metavar='path/to/data/', type = str,
+        help ='Data files for peptide subpositions')
+    args = parser.parse_args()
+
+    header, vcf, infocols = parse_vcf(args.vcf)
+    
+    if len(vcf) != 0: #do not add summary if the vcf file is empty.
+        df = vcf.iloc[:,:vcf.columns.get_loc("FORMAT")] 
+        df = df.replace(np.nan, '', regex=True)
+        samples = vcf.iloc[:,vcf.columns.get_loc("FORMAT"):] #split format and sample columns into separate dataframe to prevent fragmentation whilst annotating
+        header.append(f'##INFO=<ID=SPEAR,Number=.,Type=String,Description="SPEAR Tool Annotations: \'residue | region | domain | contact_type | NAb | barns_class | bloom_ace2 | VDS | serum_escape | mAb_escape | cm_mAb_escape | mAb_escape_class_1 | mAb_escape_class_2 | mAb_escape_class_3 | mAb_escape_class_4 | BEC_RES | BEC_EF  \'">') #MAKE VARIANT HEADER HGVS
+        df = annotate_s_residues(df.copy(), args.data_dir)
+
+        cols = [e for e in df.columns.to_list() if e not in ("ANN", "SUM", "SPEAR")]
+        df = df.groupby(cols, as_index = False).agg(list)
+
+        df["ANN"] = [','.join(map(str, l)) for l in df['ANN']]
+        df["SUM"] = [','.join(map(str, l)) for l in df['SUM']]
+        df["SPEAR"] = [','.join(map(str, l)) for l in df['SPEAR']]
+        infocols.append("SPEAR")
+        for col in infocols:
+            df[col] = col + "=" + df[col]
+        df['INFO'] = df[infocols].agg(';'.join, axis=1)
+        df.drop(infocols, axis = 1, inplace = True)
+
+        cols = df.columns.to_list()
+        cols.pop(cols.index("INFO"))
+        cols.insert(cols.index("FILTER") + 1, "INFO")
+        df = df[cols]
+        #need to sanity check before concat shape
+        vcf = pd.concat([df, samples],axis=1)
+        write_vcf(header,vcf,args.output_filename)
+    else:
+        copy(args.vcf, args.output_filename) #copy the empty vcf file so that snakemake sees command completion. 
+  
+
+if __name__ == "__main__":
+    main() 

--- a/scripts/spear_multi.smk
+++ b/scripts/spear_multi.smk
@@ -8,7 +8,7 @@ rule summarise_vcfs:
    output:
       expand(config["output_dir"] + "/per_sample_annotation/{id}.spear.annotation.summary.tsv", id = config["samples"])
    shell:
-      """convert_format.py {config[output_dir]} --vcf {input}"""
+      """convert_format.py {config[output_dir]} {config[data_dir]} --vcf {input}"""
 
 rule split_vcfs:
    input:
@@ -26,7 +26,7 @@ rule spear:
    output:
       config["output_dir"] + "/all_samples.spear.vcf"
    shell:
-      "summarise_snpeff.py {output} {input} {config[data_dir]}"
+      "summarise_snpeff.py {output} {input} {config[data_dir]} ; spear_annotate.py {output} {output} {config[data_dir]} "
 
 rule snpeff:
    input:

--- a/scripts/spear_single.smk
+++ b/scripts/spear_single.smk
@@ -8,7 +8,7 @@ rule summarise_vcfs:
    output:
       expand(config["output_dir"] + "/per_sample_annotation/{id}.spear.annotation.summary.tsv", id = config["samples"])
    shell:
-      """convert_format.py {config[output_dir]} --vcf {input}"""
+      """convert_format.py {config[output_dir]} {config[data_dir]} --vcf {input}"""
 
 rule spear:
    input:
@@ -16,7 +16,7 @@ rule spear:
    output:
       config["output_dir"] + "/final_vcfs/{id}.spear.vcf" 
    shell:
-      "summarise_snpeff.py {output} {input} {config[data_dir]}"
+      "summarise_snpeff.py {output} {input} {config[data_dir]} ; spear_annotate.py {output} {output} {config[data_dir]}"
 
 if config["vcf"] == True:
    rule snpeff:


### PR DESCRIPTION
This branch includes a rework of the spear annotation and snpeff summary that was previously performed in summarise_snpeff.py. 

To better clarify which compenents of the VCF INFO field are summaries of SnpEff annotation and which are new annotation added by SPEAR, the SPEAR field has been split into SUM and SPEAR fields, where SUM is a summary of SnpEff annotation (along with tilde delimited residue list at end of field) and SPEAR contains the new annotation added by SPEAR. 

Additionally, the SPEAR info field is now comma delimited by residue, rather than complex internal delimiting of scores between residues from a single variant. 

Finally, this branch adds contextual scores for bloom calculator scores (BEC_RES, BEF_EF and new BEC_EF_sample in score summary). 